### PR TITLE
DPL-612: Add back multiplier to curve

### DIFF
--- a/src/config/quantTypes.json
+++ b/src/config/quantTypes.json
@@ -1278,12 +1278,13 @@
     },
     "conversion": {
       "factors": {
+        "mult": 1.62,
         "min": 1.811240654,
         "max": 55.58274833,
         "n": -3.02450536,
         "ec_50": 38.00059141
       },
-      "expression": "(min+(max-min)/(1+10^(n*(log10(ORIGINAL_VALUE)-log10(ec_50)))))",
+      "expression": "(min+(max-min)/(1+10^(n*(log10(mult*ORIGINAL_VALUE)-log10(ec_50)))))",
       "decimalPlaces": 3
     },
     "grid": {

--- a/tests/e2e/fixtures/tapestationRequest.json
+++ b/tests/e2e/fixtures/tapestationRequest.json
@@ -6,7 +6,7 @@
         {
           "barcode": "NT1",
           "key": "molarity",
-          "value": 48.17,
+          "value": 53.656,
           "units": "nM",
           "cv": 84.364,
           "assay_type": "Heron TapeStation Tubes",
@@ -15,7 +15,7 @@
         {
           "barcode": "NT3",
           "key": "molarity",
-          "value": 47.372,
+          "value": 53.421,
           "units": "nM",
           "cv": 4.89,
           "assay_type": "Heron TapeStation Tubes",
@@ -24,7 +24,7 @@
         {
           "barcode": "NT5",
           "key": "molarity",
-          "value": 52.044,
+          "value": 54.716,
           "units": "nM",
           "cv": 52.094,
           "assay_type": "Heron TapeStation Tubes",
@@ -33,7 +33,7 @@
         {
           "barcode": "NT6",
           "key": "molarity",
-          "value": 42.873,
+          "value": 51.974,
           "units": "nM",
           "cv": 19.301,
           "assay_type": "Heron TapeStation Tubes",
@@ -42,7 +42,7 @@
         {
           "barcode": "NT4",
           "key": "molarity",
-          "value": 45.745,
+          "value": 52.922,
           "units": "nM",
           "cv": 17.251,
           "assay_type": "Heron TapeStation Tubes",
@@ -51,7 +51,7 @@
         {
           "barcode": "NT2",
           "key": "molarity",
-          "value": 41.207,
+          "value": 51.378,
           "units": "nM",
           "cv": 14.279,
           "assay_type": "Heron TapeStation Tubes",

--- a/tests/unit/QuantFile.spec.js
+++ b/tests/unit/QuantFile.spec.js
@@ -311,40 +311,6 @@ describe('QuantFile.vue', () => {
     })
   })
 
-  describe.skip('Heron qPCR', () => {
-    beforeEach(async () => {
-      quantFile = new cmp({
-        propsData: {
-          quant: 'heronQPCR',
-          filename: 'HT_132817_2897_2945_2956_HERON_16_2_22_results.csv',
-        },
-      })
-      plate = fs.readFileSync(
-        './tests/e2e/fixtures/HT_132817_2897_2945_2956_HERON_16_2_22_results.csv',
-        'ascii'
-      )
-      file = new File(
-        [plate],
-        'HT_132817_2897_2945_2956_HERON_16_2_22_results.csv',
-        { type: 'text/plain' }
-      )
-    })
-
-    it('will have a filename', () => {
-      expect(quantFile.filename).toEqual(
-        'HT_132817_2897_2945_2956_HERON_16_2_22_results.csv'
-      )
-    })
-
-    it('will have a parsed filename', () => {
-      expect(quantFile.parsedFilename).toEqual('132817')
-    })
-
-    it('will have a barcode from file name', () => {
-      expect(quantFile.barcodeFromFileName).toEqual('HT-132817')
-    })
-  })
-
   describe('Heron TapeStation Tubes', () => {
     beforeEach(async () => {
       plate = fs.readFileSync(

--- a/tests/unit/QuantType.spec.js
+++ b/tests/unit/QuantType.spec.js
@@ -617,7 +617,7 @@ describe('quantType', () => {
 
     it('must have the correct conversion expression', () => {
       expect(quantType.replicateOptions.conversionExpression).toEqual(
-        '(1.811240654+(55.58274833-1.811240654)/(1+10^(-3.02450536*(log10(ORIGINAL_VALUE)-log10(38.00059141)))))'
+        '(1.811240654+(55.58274833-1.811240654)/(1+10^(-3.02450536*(log10(1.62*ORIGINAL_VALUE)-log10(38.00059141)))))'
       )
     })
   })


### PR DESCRIPTION
Closes #205 

Changes proposed in this pull request:

* Add the 1.62 multiplier back into the curve formula as the curve was fitted based on data that had been transformed already.
