### PR TITLE
DPL-841: Remove TapeStation curve fitting

### DIFF
--- a/src/config/quantTypes.json
+++ b/src/config/quantTypes.json
@@ -1276,17 +1276,6 @@
         "assay_version"
       ]
     },
-    "conversion": {
-      "factors": {
-        "mult": 1.62,
-        "min": 1.811240654,
-        "max": 55.58274833,
-        "n": -3.02450536,
-        "ec_50": 38.00059141
-      },
-      "expression": "(min+(max-min)/(1+10^(n*(log10(mult*ORIGINAL_VALUE)-log10(ec_50)))))",
-      "decimalPlaces": 3
-    },
     "grid": {
       "numberOfRows": 8,
       "numberOfColumns": 12

--- a/src/config/quantTypes.json
+++ b/src/config/quantTypes.json
@@ -1254,7 +1254,7 @@
       "units": "nM",
       "assay": {
         "type": "Heron TapeStation Tubes",
-        "version": "v2.0"
+        "version": "v3.0"
       },
       "barcodeSource": "id",
       "outlier": {

--- a/src/config/quantTypes.json
+++ b/src/config/quantTypes.json
@@ -1262,7 +1262,7 @@
         "threshold": 15
       },
       "warningThreshold": {
-        "value": 3.08642,
+        "value": 5,
         "shortMessage": "low conc",
         "message": "TapeStation may not be accurate at this low concentration"
       },

--- a/tests/e2e/fixtures/tapestationRequest.json
+++ b/tests/e2e/fixtures/tapestationRequest.json
@@ -10,7 +10,7 @@
           "units": "nM",
           "cv": 84.364,
           "assay_type": "Heron TapeStation Tubes",
-          "assay_version": "v2.0"
+          "assay_version": "v3.0"
         },
         {
           "barcode": "NT3",
@@ -19,7 +19,7 @@
           "units": "nM",
           "cv": 4.89,
           "assay_type": "Heron TapeStation Tubes",
-          "assay_version": "v2.0"
+          "assay_version": "v3.0"
         },
         {
           "barcode": "NT5",
@@ -28,7 +28,7 @@
           "units": "nM",
           "cv": 52.094,
           "assay_type": "Heron TapeStation Tubes",
-          "assay_version": "v2.0"
+          "assay_version": "v3.0"
         },
         {
           "barcode": "NT6",
@@ -37,7 +37,7 @@
           "units": "nM",
           "cv": 19.301,
           "assay_type": "Heron TapeStation Tubes",
-          "assay_version": "v2.0"
+          "assay_version": "v3.0"
         },
         {
           "barcode": "NT4",
@@ -46,7 +46,7 @@
           "units": "nM",
           "cv": 17.251,
           "assay_type": "Heron TapeStation Tubes",
-          "assay_version": "v2.0"
+          "assay_version": "v3.0"
         },
         {
           "barcode": "NT2",
@@ -55,7 +55,7 @@
           "units": "nM",
           "cv": 14.279,
           "assay_type": "Heron TapeStation Tubes",
-          "assay_version": "v2.0"
+          "assay_version": "v3.0"
         }
       ]
     }

--- a/tests/e2e/fixtures/tapestationRequest.json
+++ b/tests/e2e/fixtures/tapestationRequest.json
@@ -6,7 +6,7 @@
         {
           "barcode": "NT1",
           "key": "molarity",
-          "value": 53.656,
+          "value": 69.667,
           "units": "nM",
           "cv": 84.364,
           "assay_type": "Heron TapeStation Tubes",
@@ -15,7 +15,7 @@
         {
           "barcode": "NT3",
           "key": "molarity",
-          "value": 53.421,
+          "value": 66.967,
           "units": "nM",
           "cv": 4.89,
           "assay_type": "Heron TapeStation Tubes",
@@ -24,7 +24,7 @@
         {
           "barcode": "NT5",
           "key": "molarity",
-          "value": 54.716,
+          "value": 91.35,
           "units": "nM",
           "cv": 52.094,
           "assay_type": "Heron TapeStation Tubes",
@@ -33,7 +33,7 @@
         {
           "barcode": "NT6",
           "key": "molarity",
-          "value": 51.974,
+          "value": 56,
           "units": "nM",
           "cv": 19.301,
           "assay_type": "Heron TapeStation Tubes",
@@ -42,7 +42,7 @@
         {
           "barcode": "NT4",
           "key": "molarity",
-          "value": 52.922,
+          "value": 62.325,
           "units": "nM",
           "cv": 17.251,
           "assay_type": "Heron TapeStation Tubes",
@@ -51,7 +51,7 @@
         {
           "barcode": "NT2",
           "key": "molarity",
-          "value": 51.378,
+          "value": 53.033,
           "units": "nM",
           "cv": 14.279,
           "assay_type": "Heron TapeStation Tubes",

--- a/tests/unit/QuantType.spec.js
+++ b/tests/unit/QuantType.spec.js
@@ -617,7 +617,7 @@ describe('quantType', () => {
 
     it('must have the correct conversion expression', () => {
       expect(quantType.replicateOptions.conversionExpression).toEqual(
-        '(1.811240654+(55.58274833-1.811240654)/(1+10^(-3.02450536*(log10(1.62*ORIGINAL_VALUE)-log10(38.00059141)))))'
+        '(ORIGINAL_VALUE)'
       )
     })
   })


### PR DESCRIPTION
Closes #241 

Changes proposed in this pull request:

* Remove modification of values before being submitted to Sequencescape.
* Set the warning threshold for low concentrations.
  * This one is curious.  It was previously set to a value that, when multiplied by the v1.0 modifier of 1.62, becomes 5.  I checked with Rory and he said that we should just set it to 5.  It is applied to the raw values from the machine so it never did need to be modified for the multiplier.  Changing the multiplier doesn't change the physical characteristics of the machine in terms of its accuracy at low concentrations.
* Make the assay be v3.0 now so we can identify how the values were modified when they're observed in Sequencescape.
