### PR TITLE
Added --openssl-legacy-provide to NODE_OPTIONS on serve and build scripts in package.json

### DIFF
--- a/.github/workflows/manual_build.yml
+++ b/.github/workflows/manual_build.yml
@@ -21,11 +21,11 @@ jobs:
     name: Build Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version-file: '.nvmrc'
       - name: Install
         run: yarn install
       - name: Compile build

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ resolutions to fix the version incompatibility issue with node.
 yarn run serve
 ```
 
+Added --openssl-legacy-provide to NODE_OPTIONS on serve and build scripts in package.json to resolve the error:0308010C:digital envelope routines::unsupported discussed here https://github.com/vuejs/vue-cli/issues/6770. This can be removed later when the issue is resolved.
+
 ### Compiles and minifies for production
 
 ```shell

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "serve": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service serve",
+    "build": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e",
     "lint": "vue-cli-service lint",


### PR DESCRIPTION
…ipts in package.json to resolve the error digital envelope routines::unsupported

Closes #

#### Changes proposed in this pull request

- Added --openssl-legacy-provide to NODE_OPTIONS on serve and build scripts in package.json to resolve the error:0308010C:digital envelope routines::unsupported discussed here https://github.com/vuejs/vue-cli/issues/6770. This can be removed later when the issue is resolved.

Issue:

<img width="1194" alt="image" src="https://github.com/sanger/quanthub/assets/93536758/c3c31646-46e6-4c3a-a6a8-f69df58bede3">


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
