### PR TITLE
Removed dest from the npm run build since build outDir is added in vite config

### DIFF
--- a/compile-build.sh
+++ b/compile-build.sh
@@ -8,7 +8,7 @@
 set -ev
 
 # Building assets
-npm run build -- --dest $2/public --report
+npm run build
 
 # Storing revision hash
 git rev-parse HEAD > $2/REVISION


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Removed dest from the npm run build since build outDir is added in vite config

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
